### PR TITLE
rename metric, remove new field

### DIFF
--- a/analyses/metric_sql.sql
+++ b/analyses/metric_sql.sql
@@ -2,7 +2,7 @@ select
     *
 from {{
     metrics.calculate(
-        metric('average_order_profit_pct'),
+        metric('average_order_cost'),
         grain='month',
         dimensions=['is_drink_order']
     )

--- a/models/marts/_marts_metrics.yml
+++ b/models/marts/_marts_metrics.yml
@@ -1,15 +1,15 @@
 version: 2
 
 metrics:
-  - name: average_order_profit_pct
-    label: Average Profit Percentage per Order
+  - name: average_order_cost
+    label: Average Cost per Order
     model: ref('fct_orders')
     
     timestamp: ordered_at
     time_grains: [day, week, month]
 
     calculation_method: average
-    expression: order_profit_pct
+    expression: order_cost
 
     dimensions:
       - is_drink_order

--- a/models/marts/fct_orders.sql
+++ b/models/marts/fct_orders.sql
@@ -82,8 +82,6 @@ joined as (
 
         order_supplies_summary.order_cost,
 
-        (order_items_summary.subtotal - order_supplies_summary.order_cost) / order_items_summary.subtotal as order_profit_pct, 
-
         -- rank this order for the customer
         row_number() over (
             partition by orders.customer_id


### PR DESCRIPTION
This PR removes the step to create a new field in `fct_orders`, and instead builds the metric off of the field we play with in step 2

<img width="1378" alt="image" src="https://user-images.githubusercontent.com/73915542/193601775-d0599120-0dfd-44e0-9529-50a5833ed717.png">
